### PR TITLE
fix: remove debug prints, fix characters() bytes type, fix singleton key

### DIFF
--- a/complex_tokenization/graph.py
+++ b/complex_tokenization/graph.py
@@ -21,10 +21,9 @@ class GraphVertex:
         if not GraphSettings.USE_SINGLETONS:
             return super().__new__(cls)
 
-        key = (args, tuple(sorted(kwargs.items())))
+        key = (cls, args, tuple(sorted(kwargs.items())))
         if key not in cls._instances:
             cls._instances[key] = super().__new__(cls)
-            cls._instances[key].__init__(*args, **kwargs)  # optional, if side effects desired
         return cls._instances[key]
 
     def __bytes__(self):
@@ -111,10 +110,10 @@ class NodesSequence(GraphVertex):
                     break
                 yield tuple(self.nodes[i:j])
 
-    def merge(self, token: Node, merge: tuple[Node, ...]):
+    def merge(self, token: Node, merge: tuple["GraphVertex", ...]):
         m = len(merge)
         i = 0
-        out: list[Node] = []
+        out: list[GraphVertex] = []
         nodes = self.nodes  # local alias
 
         while i <= len(nodes) - m:
@@ -158,9 +157,7 @@ class NodesSequence(GraphVertex):
         if isinstance(other, NodesSequence):
             return NodesSequence(self.nodes + other.nodes)
         if isinstance(other, Node):
-            print("other", type(other))
-            print(self.nodes, type(self.nodes))
-            return NodesSequence(self.nodes + tuple([other]))
+            return NodesSequence(self.nodes + (other,))
 
 
 @dataclass(frozen=True, slots=True)
@@ -230,8 +227,4 @@ class UnconnectedGraphs(GraphVertex):
     def dot(self, level=0) -> Iterable[str]:
         for subgraph in self.subgraphs:
             yield from subgraph.dot(level)
-
-
-
-
 

--- a/complex_tokenization/graphs/units.py
+++ b/complex_tokenization/graphs/units.py
@@ -4,7 +4,7 @@ from complex_tokenization.graph import GraphVertex, Node, NodesSequence
 
 
 def characters(s: str) -> GraphVertex:
-    nodes = [Node(c) for c in s]
+    nodes = [Node(c.encode("utf-8")) for c in s]
 
     if len(nodes) == 1:
         return nodes[0]

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -17,7 +17,8 @@ def readable_merges(graph: GraphVertex):
 
 class TestUnitsWord:
     def test_characters_split(self):
-        assert characters("שלום") == NodesSequence((Node("ש"), Node("ל"), Node("ו"), Node("ם")))
+        assert characters("שלום") == NodesSequence((
+            Node("ש".encode()), Node("ל".encode()), Node("ו".encode()), Node("ם".encode())))
 
     def test_utf8_split(self):
         assert utf8("שלום") == NodesSequence((Node(value=b'\xd7'), Node(value=b'\xa9'),


### PR DESCRIPTION
## Summary
- Remove leftover `print()` debug statements in `NodesSequence.__add__`
- Fix `characters()` unit splitter to encode strings as UTF-8 bytes (was passing raw `str` to `Node(value: bytes)`)
- Include `cls` in singleton cache key to prevent collisions between different `GraphVertex` subclasses with same args
- Remove redundant explicit `__init__` call in `__new__` that caused double initialization on cached singletons
- Fix type annotation in `NodesSequence.merge` (`out` list holds `GraphVertex`, not just `Node`)

## What improved
- `characters()` now correctly produces byte-valued nodes consistent with `utf8()` and `utf8_clusters()`
- Singleton cache no longer risks returning a `Node` instance when a `NodesSequence` is requested with the same args
- No more spurious print output when adding a `Node` to a `NodesSequence`

## Test plan
- [x] All 33 existing tests pass
- [x] `ruff check .` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)