### PR TITLE
ci: fix CI by adding examples deps, add pytest-timeout (5 min)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,10 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+draw = [
+    "graphviz",
+    "Pillow",
+]
 examples = [
     "datasets",
     "tokenizers",
@@ -21,7 +25,7 @@ dev = [
     "pytest",
     "pytest-timeout",
     "pytest-xdist", # For parallel test execution
-    "complex-tokenization[examples]",
+    "complex-tokenization[draw,examples]",
 ]
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,10 +11,17 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+examples = [
+    "datasets",
+    "tokenizers",
+    "transformers",
+]
 dev = [
     "ruff",
     "pytest",
+    "pytest-timeout",
     "pytest-xdist", # For parallel test execution
+    "complex-tokenization[examples]",
 ]
 
 
@@ -43,3 +50,4 @@ select = [
 [tool.pytest.ini_options]
 addopts = "-v"
 testpaths = ["complex_tokenization", "tests"]
+timeout = 300

--- a/tests/test_singletons.py
+++ b/tests/test_singletons.py
@@ -1,4 +1,4 @@
-from complex_tokenization.graph import GraphVertex, Node, NodesSequence
+from complex_tokenization.graph import Node, NodesSequence
 from complex_tokenization.graphs.settings import GraphSettings
 from complex_tokenization.graphs.units import utf8
 

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -76,4 +76,4 @@ class TestTrainer:
     def test_characters_non_ascii_produce_valid_bytes(self):
         from complex_tokenization.graphs.units import characters
         graph = characters("שלום")
-        assert bytes(graph) == "שלום".encode("utf-8")
+        assert bytes(graph) == "שלום".encode()


### PR DESCRIPTION
## Summary
- Add `[examples]` optional dependency group (`datasets`, `tokenizers`, `transformers`) and include it in `[dev]` so CI installs everything needed for tokenizer tests
- Add `pytest-timeout` with 300s (5 min) default to prevent runaway training in tests

Stacked on #3 and #2.

## What improved
- CI should now pass (previously failed with `ModuleNotFoundError: No module named 'datasets'`)
- All test runs are capped at 5 minutes per test

## Test plan
- [x] All 48 tests pass locally
- [x] `ruff check .` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)