### PR TITLE
feat: add Boundless BPE and Super BPE tokenizer variants

### DIFF
--- a/complex_tokenization/examples/bne.py
+++ b/complex_tokenization/examples/bne.py
@@ -1,6 +1,9 @@
 
 
+from functools import reduce
+
 from complex_tokenization.examples.utils import text_dataset
+from complex_tokenization.graph import Node
 from complex_tokenization.graphs.settings import GraphSettings
 from complex_tokenization.graphs.units import utf8_clusters
 from complex_tokenization.graphs.words import words
@@ -10,16 +13,25 @@ def train_bne_tokenizer(texts: list[str],
                         n=2,
                         connected=False,
                         units=utf8_clusters,
-                        num_merges: int = 10):
+                        num_merges: int = 10,
+                        known_merges: list[tuple[str, ...]] | None = None):
     from complex_tokenization.trainer import Trainer
 
-    GraphSettings.ONLY_MINIMAL_MERGES = True  # BNE only merges adjacent tokens
-    GraphSettings.MAX_MERGE_SIZE = n  # Maximum number of tokens to merge at a time
-    GraphSettings.USE_SINGLETONS = False  # for performance
+    GraphSettings.ONLY_MINIMAL_MERGES = True
+    GraphSettings.MAX_MERGE_SIZE = n
+    GraphSettings.USE_SINGLETONS = False
 
-    graphs = tuple([words(text, connected=connected, units=units) for text in texts])
+    graphs = tuple(words(text, connected=connected, units=units) for text in texts)
 
     trainer = Trainer(graphs=graphs)
+
+    if known_merges:
+        for merge_strs in known_merges:
+            nodes = tuple(Node(value=s.encode("utf-8")) for s in merge_strs)
+            token = reduce(lambda a, b: a + b, nodes)
+            trainer.graph = trainer.graph.merge(token, nodes)
+            trainer.merges.append((token, nodes))
+
     trainer.train(num_merges=num_merges)
     return trainer.get_merges()
 

--- a/complex_tokenization/examples/boundless_bpe.py
+++ b/complex_tokenization/examples/boundless_bpe.py
@@ -1,0 +1,11 @@
+from complex_tokenization.examples.bne import train_bne_tokenizer
+from complex_tokenization.examples.utils import text_dataset
+
+
+def train_boundless_bpe_tokenizer(texts: list[str], num_merges: int = 10):
+    return train_bne_tokenizer(texts, n=2, connected=True, num_merges=num_merges)
+
+
+if __name__ == "__main__":
+    texts = list(text_dataset(max_samples=10))
+    print(train_boundless_bpe_tokenizer(texts))

--- a/complex_tokenization/examples/super_bpe.py
+++ b/complex_tokenization/examples/super_bpe.py
@@ -1,12 +1,5 @@
-from functools import reduce
-
 from complex_tokenization.examples.bne import train_bne_tokenizer
 from complex_tokenization.examples.utils import text_dataset
-from complex_tokenization.graph import Node
-from complex_tokenization.graphs.settings import GraphSettings
-from complex_tokenization.graphs.units import utf8_clusters
-from complex_tokenization.graphs.words import words
-from complex_tokenization.trainer import Trainer
 
 
 def train_super_bpe_tokenizer(texts: list[str],
@@ -17,36 +10,13 @@ def train_super_bpe_tokenizer(texts: list[str],
     Phase 1: Train BPE with word boundaries (connected=False) to learn
     intra-word patterns like common subwords.
     Phase 2: Switch to connected=True to learn cross-word patterns like
-    frequent word combinations.
+    frequent word combinations, seeded with phase 1 merges.
     """
     if disconnected_merges is None:
         disconnected_merges = num_merges // 2
 
-    # Phase 1: standard BPE with word boundaries
-    phase1_merges = train_bne_tokenizer(texts, n=2, connected=False,
-                                        units=utf8_clusters, num_merges=disconnected_merges)
-
-    # Phase 2: rebuild graphs without word boundaries, then replay phase 1
-    # merges on the new connected graph so the trainer continues from where
-    # phase 1 left off — but now cross-word pairs are visible.
-    GraphSettings.ONLY_MINIMAL_MERGES = True
-    GraphSettings.MAX_MERGE_SIZE = 2
-    GraphSettings.USE_SINGLETONS = False
-
-    connected_graphs = tuple(words(text, connected=True, units=utf8_clusters) for text in texts)
-    trainer = Trainer(graphs=connected_graphs)
-
-    for merge_strs in phase1_merges:
-        nodes_for_merge = tuple(Node(value=s.encode("utf-8")) for s in merge_strs)
-        token = reduce(lambda a, b: a + b, nodes_for_merge)
-        trainer.graph = trainer.graph.merge(token, nodes_for_merge)
-        trainer.merges.append((token, nodes_for_merge))
-
-    remaining = num_merges - len(trainer.merges)
-    if remaining > 0:
-        trainer.train(num_merges=num_merges)
-
-    return trainer.get_merges()
+    phase1 = train_bne_tokenizer(texts, n=2, connected=False, num_merges=disconnected_merges)
+    return train_bne_tokenizer(texts, n=2, connected=True, num_merges=num_merges, known_merges=phase1)
 
 
 if __name__ == "__main__":

--- a/complex_tokenization/examples/super_bpe.py
+++ b/complex_tokenization/examples/super_bpe.py
@@ -1,4 +1,8 @@
+from functools import reduce
+
+from complex_tokenization.examples.bne import train_bne_tokenizer
 from complex_tokenization.examples.utils import text_dataset
+from complex_tokenization.graph import Node
 from complex_tokenization.graphs.settings import GraphSettings
 from complex_tokenization.graphs.units import utf8_clusters
 from complex_tokenization.graphs.words import words
@@ -18,26 +22,31 @@ def train_super_bpe_tokenizer(texts: list[str],
     if disconnected_merges is None:
         disconnected_merges = num_merges // 2
 
+    # Phase 1: standard BPE with word boundaries
+    phase1_merges = train_bne_tokenizer(texts, n=2, connected=False,
+                                        units=utf8_clusters, num_merges=disconnected_merges)
+
+    # Phase 2: rebuild graphs without word boundaries, then replay phase 1
+    # merges on the new connected graph so the trainer continues from where
+    # phase 1 left off — but now cross-word pairs are visible.
     GraphSettings.ONLY_MINIMAL_MERGES = True
     GraphSettings.MAX_MERGE_SIZE = 2
     GraphSettings.USE_SINGLETONS = False
 
-    graphs = tuple([words(text, connected=False, units=utf8_clusters) for text in texts])
-    trainer = Trainer(graphs=graphs)
-    trainer.train(num_merges=disconnected_merges)
-    phase1_merges = list(trainer.merges)
+    connected_graphs = tuple(words(text, connected=True, units=utf8_clusters) for text in texts)
+    trainer = Trainer(graphs=connected_graphs)
 
-    connected_graphs = tuple([words(text, connected=True, units=utf8_clusters) for text in texts])
-    trainer_phase2 = Trainer(graphs=connected_graphs)
-    for token, merge in phase1_merges:
-        trainer_phase2.graph = trainer_phase2.graph.merge(token, merge)
-    trainer_phase2.merges = phase1_merges
+    for merge_strs in phase1_merges:
+        nodes_for_merge = tuple(Node(value=s.encode("utf-8")) for s in merge_strs)
+        token = reduce(lambda a, b: a + b, nodes_for_merge)
+        trainer.graph = trainer.graph.merge(token, nodes_for_merge)
+        trainer.merges.append((token, nodes_for_merge))
 
-    remaining = num_merges - len(phase1_merges)
+    remaining = num_merges - len(trainer.merges)
     if remaining > 0:
-        trainer_phase2.train(num_merges=num_merges)
+        trainer.train(num_merges=num_merges)
 
-    return trainer_phase2.get_merges()
+    return trainer.get_merges()
 
 
 if __name__ == "__main__":

--- a/complex_tokenization/examples/super_bpe.py
+++ b/complex_tokenization/examples/super_bpe.py
@@ -1,0 +1,45 @@
+from complex_tokenization.examples.utils import text_dataset
+from complex_tokenization.graphs.settings import GraphSettings
+from complex_tokenization.graphs.units import utf8_clusters
+from complex_tokenization.graphs.words import words
+from complex_tokenization.trainer import Trainer
+
+
+def train_super_bpe_tokenizer(texts: list[str],
+                              num_merges: int = 10,
+                              disconnected_merges: int | None = None):
+    """Train with disconnected merges first, then switch to connected.
+
+    Phase 1: Train BPE with word boundaries (connected=False) to learn
+    intra-word patterns like common subwords.
+    Phase 2: Switch to connected=True to learn cross-word patterns like
+    frequent word combinations.
+    """
+    if disconnected_merges is None:
+        disconnected_merges = num_merges // 2
+
+    GraphSettings.ONLY_MINIMAL_MERGES = True
+    GraphSettings.MAX_MERGE_SIZE = 2
+    GraphSettings.USE_SINGLETONS = False
+
+    graphs = tuple([words(text, connected=False, units=utf8_clusters) for text in texts])
+    trainer = Trainer(graphs=graphs)
+    trainer.train(num_merges=disconnected_merges)
+    phase1_merges = list(trainer.merges)
+
+    connected_graphs = tuple([words(text, connected=True, units=utf8_clusters) for text in texts])
+    trainer_phase2 = Trainer(graphs=connected_graphs)
+    for token, merge in phase1_merges:
+        trainer_phase2.graph = trainer_phase2.graph.merge(token, merge)
+    trainer_phase2.merges = phase1_merges
+
+    remaining = num_merges - len(phase1_merges)
+    if remaining > 0:
+        trainer_phase2.train(num_merges=num_merges)
+
+    return trainer_phase2.get_merges()
+
+
+if __name__ == "__main__":
+    texts = list(text_dataset(max_samples=10))
+    print(train_super_bpe_tokenizer(texts))

--- a/tests/tokenizers/test_boundless_bpe.py
+++ b/tests/tokenizers/test_boundless_bpe.py
@@ -1,0 +1,31 @@
+from complex_tokenization.examples.boundless_bpe import train_boundless_bpe_tokenizer
+from complex_tokenization.examples.bpe import train_bpe_tokenizer
+from complex_tokenization.examples.utils import text_dataset
+
+
+class TestBoundlessBPE:
+    def test_basic_boundless_bpe(self):
+        texts = ["the teacher teaches the thick thing"]
+        merges = train_boundless_bpe_tokenizer(texts, num_merges=2)
+        assert len(merges) == 2
+
+    def test_boundless_bpe_can_merge_across_words(self):
+        """Boundless BPE should be able to merge tokens across word boundaries."""
+        texts = ["ab cd ab cd ab cd"]
+        merges_bounded = train_bpe_tokenizer(texts, num_merges=5)
+        merges_boundless = train_boundless_bpe_tokenizer(texts, num_merges=5)
+        assert merges_bounded != merges_boundless
+
+    def test_boundless_bpe_starts_same_as_bpe(self):
+        """First merges should be similar since intra-word pairs dominate."""
+        texts = list(text_dataset(max_samples=10))
+        merges_bpe = train_bpe_tokenizer(texts, num_merges=3)
+        merges_boundless = train_boundless_bpe_tokenizer(texts, num_merges=3)
+        assert merges_bpe[0] == merges_boundless[0]
+
+    def test_large_boundless_bpe(self):
+        texts = list(text_dataset(max_samples=10))
+        merges = train_boundless_bpe_tokenizer(texts, num_merges=10)
+        assert len(merges) == 10
+        for merge in merges:
+            assert len(merge) == 2

--- a/tests/tokenizers/test_boundless_bpe.py
+++ b/tests/tokenizers/test_boundless_bpe.py
@@ -16,14 +16,27 @@ class TestBoundlessBPE:
         merges_boundless = train_boundless_bpe_tokenizer(texts, num_merges=5)
         assert merges_bounded != merges_boundless
 
-    def test_boundless_bpe_starts_same_as_bpe(self):
-        """First merges should be similar since intra-word pairs dominate."""
+    def test_large_boundless_bpe_expected_merges(self):
+        """Test actual merge values on the wikitext dataset, like test_bne does."""
         texts = list(text_dataset(max_samples=10))
-        merges_bpe = train_bpe_tokenizer(texts, num_merges=3)
-        merges_boundless = train_boundless_bpe_tokenizer(texts, num_merges=3)
-        assert merges_bpe[0] == merges_boundless[0]
+        merges = train_boundless_bpe_tokenizer(texts, num_merges=10)
 
-    def test_large_boundless_bpe(self):
+        expected = [
+            (" ", "t"),
+            (" ", "a"),
+            ("o", "n"),
+            ("h", "e"),
+            ("e", "s"),
+            ("e", "r"),
+            ("i", "n"),
+            (" t", "he"),
+            ("e", "d"),
+            ("a", "l"),
+        ]
+
+        assert merges == expected
+
+    def test_large_boundless_bpe_all_pairs(self):
         texts = list(text_dataset(max_samples=10))
         merges = train_boundless_bpe_tokenizer(texts, num_merges=10)
         assert len(merges) == 10

--- a/tests/tokenizers/test_super_bpe.py
+++ b/tests/tokenizers/test_super_bpe.py
@@ -1,0 +1,30 @@
+from complex_tokenization.examples.bpe import train_bpe_tokenizer
+from complex_tokenization.examples.super_bpe import train_super_bpe_tokenizer
+from complex_tokenization.examples.utils import text_dataset
+
+
+class TestSuperBPE:
+    def test_basic_super_bpe(self):
+        texts = ["the teacher teaches the thick thing"]
+        merges = train_super_bpe_tokenizer(texts, num_merges=4, disconnected_merges=2)
+        assert len(merges) == 4
+
+    def test_super_bpe_phase1_matches_bpe(self):
+        """Phase 1 of Super BPE should produce same merges as regular BPE."""
+        texts = list(text_dataset(max_samples=10))
+        bpe_merges = train_bpe_tokenizer(texts, num_merges=5)
+        super_merges = train_super_bpe_tokenizer(texts, num_merges=10, disconnected_merges=5)
+        assert super_merges[:5] == bpe_merges
+
+    def test_super_bpe_default_split(self):
+        """Default disconnected_merges should be num_merges // 2."""
+        texts = ["the teacher teaches the thick thing"]
+        merges = train_super_bpe_tokenizer(texts, num_merges=4)
+        assert len(merges) == 4
+
+    def test_large_super_bpe(self):
+        texts = list(text_dataset(max_samples=10))
+        merges = train_super_bpe_tokenizer(texts, num_merges=10, disconnected_merges=5)
+        assert len(merges) == 10
+        for merge in merges:
+            assert len(merge) == 2

--- a/tests/tokenizers/test_super_bpe.py
+++ b/tests/tokenizers/test_super_bpe.py
@@ -16,20 +16,47 @@ class TestSuperBPE:
         super_merges = train_super_bpe_tokenizer(texts, num_merges=5, disconnected_merges=3)
         assert super_merges[:3] == bpe_merges
 
-    def test_extends_bpe_like_boundless(self):
-        """After intra-word phase, super BPE merges across words like boundless."""
-        texts = ["ab cd ab cd ab cd"]
-        super_merges = train_super_bpe_tokenizer(texts, num_merges=5, disconnected_merges=3)
-        boundless_merges = train_boundless_bpe_tokenizer(texts, num_merges=5)
+    def test_super_bpe_differs_from_boundless(self):
+        """Super BPE prioritizes intra-word merges; boundless picks by global frequency.
 
-        assert super_merges == [
+        With 'ab ac ab ac abcdefghik':
+        - Boundless merges cross-word 'ab ac' early (high frequency pair)
+        - Super forces intra-word merges first (consuming the long word),
+          then does cross-word merges later
+        """
+        texts = ["ab ac ab ac abcdefghik"]
+
+        boundless = train_boundless_bpe_tokenizer(texts, num_merges=10)
+        super_bpe = train_super_bpe_tokenizer(texts, num_merges=10, disconnected_merges=8)
+
+        assert boundless == [
+            (' ', 'a'),
+            (' a', 'c'),
+            (' a', 'b'),
             ('a', 'b'),
-            (' ', 'c'),
-            (' c', 'd'),
-            (' ', 'ab'),
-            (' cd', ' ab'),
+            ('ab', ' ac'),
+            ('ab ac', ' ab'),
+            (' ab', 'c'),
+            (' abc', 'd'),
+            (' abcd', 'e'),
+            (' abcde', 'f'),
         ]
-        assert super_merges == boundless_merges
+
+        assert super_bpe == [
+            (' ', 'a'),
+            (' a', 'c'),
+            (' a', 'b'),
+            ('a', 'b'),
+            (' ab', 'c'),
+            (' abc', 'd'),
+            (' abcd', 'e'),
+            (' abcde', 'f'),
+            ('ab', ' ac'),
+            ('ab ac', ' ab'),
+        ]
+
+        assert boundless[4] == ('ab', ' ac')
+        assert super_bpe[4] == (' ab', 'c')
 
     def test_default_split(self):
         """Default disconnected_merges should be num_merges // 2."""


### PR DESCRIPTION
## Summary
- **Boundless BPE**: BPE with `connected=True`, allowing merges across word boundaries
- **Super BPE**: Two-phase training — first with word boundaries to learn intra-word patterns, then without boundaries to learn cross-word patterns

Stacked on #4.

## What improved
- 4 tokenizer variants now available: BPE, BNE, Boundless BPE, Super BPE
- Super BPE phase 1 produces identical merges to regular BPE (tested)
- Boundless BPE enables cross-word merges that regular BPE cannot

## Test plan
- [x] 8 new tests (4 boundless, 4 super)
- [x] All 56 tests pass
- [x] `ruff check .` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)