### PR TITLE
feat: export tokenizer classes from package __init__

### DIFF
--- a/complex_tokenization/__init__.py
+++ b/complex_tokenization/__init__.py
@@ -1,0 +1,15 @@
+from complex_tokenization.tokenizer import (
+    BNETokenizer,
+    BoundlessBPETokenizer,
+    BPETokenizer,
+    SuperBPETokenizer,
+    Tokenizer,
+)
+
+__all__ = [
+    "Tokenizer",
+    "BPETokenizer",
+    "BNETokenizer",
+    "BoundlessBPETokenizer",
+    "SuperBPETokenizer",
+]

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -1,0 +1,27 @@
+"""Test that key classes are importable from the top-level package."""
+
+
+class TestImports:
+    def test_import_tokenizer(self):
+        from complex_tokenization import Tokenizer
+        assert Tokenizer is not None
+
+    def test_import_bpe(self):
+        from complex_tokenization import BPETokenizer
+        assert BPETokenizer is not None
+
+    def test_import_bne(self):
+        from complex_tokenization import BNETokenizer
+        assert BNETokenizer is not None
+
+    def test_import_boundless(self):
+        from complex_tokenization import BoundlessBPETokenizer
+        assert BoundlessBPETokenizer is not None
+
+    def test_import_super(self):
+        from complex_tokenization import SuperBPETokenizer
+        assert SuperBPETokenizer is not None
+
+    def test_all_exports(self):
+        import complex_tokenization
+        assert len(complex_tokenization.__all__) == 5


### PR DESCRIPTION
## Summary
- Export all 5 tokenizer classes from `complex_tokenization.__init__`
- Users can now do `from complex_tokenization import BPETokenizer`

Stacked on #14.

## Test plan
- [x] 6 import tests pass
- [x] `ruff check .` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)