### PR TITLE
feat: add on_merge progress callback to Trainer.train

### DIFF
--- a/complex_tokenization/trainer.py
+++ b/complex_tokenization/trainer.py
@@ -1,4 +1,5 @@
 from collections import Counter
+from collections.abc import Callable
 from functools import reduce
 
 from complex_tokenization.draw import create_gif, draw_dot_content
@@ -20,7 +21,8 @@ class Trainer:
         self.graph = graph
         self.merges = []
 
-    def train(self, num_merges: int = 100, draw=False, verbose=False):
+    def train(self, num_merges: int = 100, draw=False, verbose=False,
+              on_merge: Callable[[int, int, "Node", tuple], None] | None = None):
         frames = []
 
         while True:
@@ -51,6 +53,9 @@ class Trainer:
 
             self.graph = self.graph.merge(token, nodes)
             self.merges.append((token, nodes))
+
+            if on_merge is not None:
+                on_merge(len(self.merges), num_merges, token, nodes)
 
         if draw:
             gif = create_gif(frames, save="example.gif")

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -77,3 +77,12 @@ class TestTrainer:
         from complex_tokenization.graphs.units import characters
         graph = characters("שלום")
         assert bytes(graph) == "שלום".encode()
+
+    def test_on_merge_callback(self):
+        GraphSettings.MAX_MERGE_SIZE = 2
+        GraphSettings.ONLY_MINIMAL_MERGES = True
+        graph = utf8("abab")
+        trainer = Trainer(graph=graph)
+        calls = []
+        trainer.train(num_merges=2, on_merge=lambda step, total, token, nodes: calls.append(step))
+        assert calls == [1, 2]


### PR DESCRIPTION
## Summary
- Add optional `on_merge(step, total, token, nodes)` callback to `Trainer.train()`
- Called after each merge, enabling progress bars and logging
- Backward compatible (default is `None`)

Stacked on #18.

## Test plan
- [x] New callback test passes
- [x] `ruff check .` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)