### PR TITLE
perf: skip UnconnectedGraphs reconstruction when merge is no-op

### DIFF
--- a/complex_tokenization/graph.py
+++ b/complex_tokenization/graph.py
@@ -263,7 +263,9 @@ class UnconnectedGraphs(GraphVertex):
         raise Exception("Cannot convert UnconnectedGraphs to bytes")
 
     def merge(self, token: Node, merge: tuple):
-        subgraphs = tuple(subgraph.merge(token, merge) for subgraph in self.subgraphs)
+        subgraphs = tuple(sg.merge(token, merge) for sg in self.subgraphs)
+        if subgraphs == self.subgraphs:
+            return self
         return UnconnectedGraphs(subgraphs=subgraphs)
 
     def get_merges(self) -> Iterator[tuple]:


### PR DESCRIPTION
## Summary
- Return `self` from `UnconnectedGraphs.merge()` when no subgraph changed
- Avoids unnecessary tuple and object creation

Stacked on #19.

## What improved
- Reduces allocation pressure during training, especially when merges affect few subgraphs

## Test plan
- [x] All 147 tests pass
- [x] `ruff check .` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)