### PR TITLE
perf: return self from merge when nothing changed

### DIFF
--- a/complex_tokenization/graph.py
+++ b/complex_tokenization/graph.py
@@ -127,6 +127,8 @@ class NodesSequence(GraphVertex):
             return out[0]
 
         merged_nodes = tuple(n.merge(token, merge) for n in out)
+        if merged_nodes == nodes:
+            return self
         return NodesSequence(merged_nodes)
 
     def dot(self, level=0) -> Iterable[str]:
@@ -202,6 +204,8 @@ class Tree(GraphVertex):
 
         root = self.root.merge(token, nodes)
         children = tuple(child.merge(token, nodes) for child in self.children)
+        if root == self.root and children == self.children:
+            return self
         return Tree(root=root, children=children)
 
     def __bytes__(self):


### PR DESCRIPTION
`NodesSequence.merge` and `Tree.merge` always allocated a fresh object, even when the merge didn't touch them. Since most components don't contain any given merge, that's a lot of wasted churn each training step.

Return `self` when the merged result equals the original. The `==` check is cheap: the recursive children also return `self` now, so CPython's tuple comparison short-circuits on identity instead of deep-comparing. (`FullyConnectedGraph` and `UnconnectedGraphs` already did this; this just brings the other two in line.)

**+4 lines, no new abstractions. Output is identical** (full merge sequences hashed across tokenizers — unchanged), all 136 tests pass.

Measured (50 texts / 200 merges, same machine):

| | main | this PR | speed | memory |
|---|---|---|---|---|
| BPE | 6.84s / 3.59MB | 5.69s / 3.16MB | −17% | −12% |
| BNE n=4 | 9.33s / 3.49MB | 7.88s / 2.84MB | −16% | −19% |
| Boundless | 7.43s / 3.17MB | 6.80s / 3.04MB | −8% | −4% |
| SuperBPE | 8.74s / 4.44MB | 7.38s / 2.71MB | −16% | −39% |

🤖 Generated with [Claude Code](https://claude.com/claude-code)