### PR TITLE
perf: short-circuit merge scan on first node

### DIFF
--- a/complex_tokenization/graph.py
+++ b/complex_tokenization/graph.py
@@ -116,6 +116,8 @@ class NodesSequence(GraphVertex):
 
         first = merge[0]
         while i <= n - m:
+            # Check the first node before slicing: it fails at most positions,
+            # so we avoid allocating the nodes[i:i + m] tuple in the common case.
             if nodes[i] == first and nodes[i:i + m] == merge:
                 out.append(token)
                 i += m

--- a/complex_tokenization/graph.py
+++ b/complex_tokenization/graph.py
@@ -114,8 +114,9 @@ class NodesSequence(GraphVertex):
         out: list[GraphVertex] = []
         i = 0
 
+        first = merge[0]
         while i <= n - m:
-            if nodes[i:i + m] == merge:
+            if nodes[i] == first and nodes[i:i + m] == merge:
                 out.append(token)
                 i += m
             else:


### PR DESCRIPTION
The merge scan compared a freshly-allocated tuple slice at every position — `nodes[i:i + m] == merge` builds a slice each step just to compare. Checking the first node first lets the common case (no match) skip both the slice allocation and the tuple comparison.

```python
first = merge[0]
while i <= n - m:
    if nodes[i] == first and nodes[i:i + m] == merge:
```

**+2 lines, zero memory change, output identical** (full merge sequences hashed across all tokenizers — unchanged). All 136 tests pass.

Measured (50 texts / 200 merges, same machine, peak memory unchanged at each tokenizer's baseline):

| | main | this PR |
|---|---|---|
| BPE | 5.74s | 5.50s (−4.2%) |
| BNE n=4 | 7.91s | 7.69s (−2.8%) |
| Boundless | 6.81s | 6.50s (−4.6%) |
| SuperBPE | 7.34s | 7.10s (−3.3%) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)