### PR TITLE
perf: hash Node by its bytes directly

### DIFF
--- a/complex_tokenization/graph.py
+++ b/complex_tokenization/graph.py
@@ -63,6 +63,11 @@ class Node(GraphVertex):
             return False
         return self.value == other.value
 
+    def __hash__(self):
+        # hash(bytes) is cached by CPython; the dataclass default hash((value,))
+        # rebuilds and rehashes a 1-tuple on every call.
+        return hash(self.value)
+
     def __add__(self, other):
         if isinstance(other, NodesSequence):
             return NodesSequence(tuple([self]) + other.nodes)


### PR DESCRIPTION
`Node` is a frozen dataclass, so its default `__hash__` is `hash((self.value,))` — it builds and hashes a fresh 1-tuple on **every** call. `Node` gets hashed millions of times (every merge candidate is a tuple of `Node`s counted in a `Counter`), so that adds up.

```python
def __hash__(self):
    return hash(self.value)
```

Why it's faster: CPython **caches the hash of `bytes`** objects, so `hash(self.value)` is essentially free after the first call and allocates nothing. The default tuple hash is neither cached nor allocation-free.

**+4 lines, output identical** (consistent with `__eq__`, which compares `value`), all 137 tests pass. Memory unchanged — strictly fewer transient allocations.

Speed (best of 3, 50 texts / 200 merges):

| | main | this PR |
|---|---|---|
| BPE | 0.900s | 0.844s (−7%) |
| BNE n=4 | 1.593s | 1.444s (−9%) |
| Boundless | 0.992s | 0.960s (−3%) |

(I also tried replacing `isinstance` with `type(...) is Node` in `__eq__` — no measurable effect, so left it alone.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)