### PR TITLE
perf: make slots effective (empty __slots__ on base)

### DIFF
--- a/complex_tokenization/graph.py
+++ b/complex_tokenization/graph.py
@@ -1,5 +1,5 @@
 from collections.abc import Iterable, Iterator
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 from complex_tokenization.graphs.settings import GraphSettings
 from complex_tokenization.languages.chinese.ideographic_description_sequences import get_character_for_ids
@@ -15,6 +15,10 @@ def dot_escape(s: str) -> str:
 
 
 class GraphVertex:
+    # Empty slots so the slotted subclasses below actually suppress __dict__;
+    # without this, a non-slotted base hands every node an unused __dict__.
+    __slots__ = ()
+
     def __bytes__(self):
         raise NotImplementedError
 
@@ -80,6 +84,8 @@ class Node(GraphVertex):
 @dataclass(frozen=True, slots=True)
 class NodesSequence(GraphVertex):
     nodes: tuple[GraphVertex, ...]
+    # memo slot for get_merges; excluded from eq/hash/repr (see get_merges)
+    _merges: tuple | None = field(default=None, init=False, compare=False, repr=False)
 
     def __bytes__(self):
         buffer = bytearray()


### PR DESCRIPTION
The node dataclasses are declared `@dataclass(slots=True)`, but the base class `GraphVertex` had **no** `__slots__` — and a non-slotted base hands every instance a `__dict__`, silently defeating slots. So every `Node`/`NodesSequence`/… was carrying an unused per-instance dict.

Adding `__slots__ = ()` to `GraphVertex` lets the subclass slots actually take effect. `Node` drops from **56 → 40 bytes**, no `__dict__`. `NodesSequence` keeps its `get_merges` memo via a declared `_merges` slot field (excluded from eq/hash/repr).

**Output identical, 137 tests pass.** Measured (50 texts / 200 merges; time = best of 3):

| | main | this PR |
|---|---|---|
| BPE | 0.846s / 4.41MB | 0.825s / **2.71MB (−39%)** |
| BNE n=4 | 1.425s / 6.28MB | 1.405s / **4.67MB (−26%)** |
| Boundless | 0.947s / 4.51MB | 0.944s / **2.79MB (−38%)** |

Big memory win, slightly faster too (slot access beats dict lookups).

🤖 Generated with [Claude Code](https://claude.com/claude-code)