### PR TITLE
perf: skip UnconnectedGraphs flatten when nothing is nested

### DIFF
--- a/complex_tokenization/graph.py
+++ b/complex_tokenization/graph.py
@@ -304,7 +304,10 @@ class UnconnectedGraphs(GraphVertex):
 
     def __post_init__(self):
         # Flatten nested UnconnectedGraphs so all subgraphs are at one level.
-        # Uses object.__setattr__ because the dataclass is frozen.
+        # Skip the rebuild when nothing is nested (the common case, e.g. every
+        # merge step). Uses object.__setattr__ because the dataclass is frozen.
+        if not any(isinstance(sg, UnconnectedGraphs) for sg in self.subgraphs):
+            return
         flat = []
         for sg in self.subgraphs:
             if isinstance(sg, UnconnectedGraphs):


### PR DESCRIPTION
`UnconnectedGraphs.__post_init__` flattens nested `UnconnectedGraphs` into one level — but it rebuilt a fresh list + tuple on **every** construction, including every merge step (where the subgraphs are words and never nested). Guard it: only rebuild when something is actually nested.

```python
if not any(isinstance(sg, UnconnectedGraphs) for sg in self.subgraphs):
    return
```

**Output identical, 137 tests pass.** Measured back-to-back (50 texts / 200 merges; time = best of 3):

| | main | this PR |
|---|---|---|
| BPE | 0.841s / 4.41MB | 0.833s / 4.34MB |
| BNE n=4 | 1.424s / 6.28MB | 1.414s / 6.28MB |
| Boundless | 0.951s / 4.51MB | 0.948s / 4.51MB |

Small (~1%) but consistent, and avoids a throwaway tuple allocation per merge. Behavior for genuinely nested inputs is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)