### PR TITLE
perf: pick best merge over counts.items()

### DIFF
--- a/complex_tokenization/trainer.py
+++ b/complex_tokenization/trainer.py
@@ -39,7 +39,7 @@ class Trainer:
             if not counts:
                 break
 
-            nodes = max(counts, key=lambda k: (len(k) - 1) * counts[k])
+            nodes = max(counts.items(), key=lambda kv: (len(kv[0]) - 1) * kv[1])[0]
 
             if verbose:
                 print("Merging", nodes, "count=", counts[nodes])

--- a/complex_tokenization/trainer.py
+++ b/complex_tokenization/trainer.py
@@ -6,6 +6,12 @@ from complex_tokenization.graph import GraphVertex, Tree, UnconnectedGraphs
 from complex_tokenization.graphs.units import utf8
 
 
+def _merge_score(item):
+    # item is a (nodes, count) pair; merging a k-tuple removes k-1 nodes.
+    nodes, count = item
+    return (len(nodes) - 1) * count
+
+
 class Trainer:
     def __init__(self, graph: GraphVertex | None = None, graphs: tuple[GraphVertex, ...] | None = None):
         if graphs is None and graph is None:
@@ -39,7 +45,7 @@ class Trainer:
             if not counts:
                 break
 
-            nodes = max(counts.items(), key=lambda kv: (len(kv[0]) - 1) * kv[1])[0]
+            nodes = max(counts.items(), key=_merge_score)[0]
 
             if verbose:
                 print("Merging", nodes, "count=", counts[nodes])


### PR DESCRIPTION
Choosing the best merge did a dict lookup per candidate:

```python
nodes = max(counts, key=lambda k: (len(k) - 1) * counts[k])   # counts[k] = re-lookup
```

Iterating `counts.items()` hands the count straight to the key function:

```python
nodes = max(counts.items(), key=lambda kv: (len(kv[0]) - 1) * kv[1])[0]
```

Same iteration order (insertion order either way), so the chosen merge and its tie-breaking are **identical** — the exact-merge parity tests cover this.

**Output identical, 137 tests pass.** Measured back-to-back (50 texts / 200 merges; time = best of 3):

| | main | this PR |
|---|---|---|
| BPE | 0.836s | 0.813s (−2.8%) |
| BNE n=4 | 1.415s | 1.280s (−9.5%) |
| Boundless | 0.950s | 0.920s (−3.2%) |

BNE gains most — it has the most candidates (up to 4-grams), so the most saved lookups. Memory unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)