### PR TITLE
perf: skip merge on subtrees the memo proves are unaffected

### DIFF
--- a/complex_tokenization/graph.py
+++ b/complex_tokenization/graph.py
@@ -132,16 +132,22 @@ class NodesSequence(GraphVertex):
         return sum(n.node_count() for n in self.nodes)
 
     def merge(self, token: Node, merge: tuple["GraphVertex", ...]):
-        m = len(merge)
         nodes = self.nodes
+
+        # _merges (when memoized) lists every mergeable subsequence in this
+        # subtree, so if the merge isn't among them nothing here changes.
+        cached = getattr(self, "_merges", None)
+        if cached is not None and merge not in cached:
+            return self
+
+        m = len(merge)
         n = len(nodes)
+        first = merge[0]
         out: list[GraphVertex] = []
         i = 0
-
-        first = merge[0]
         while i <= n - m:
-            # Check the first node before slicing: it fails at most positions,
-            # so we avoid allocating the nodes[i:i + m] tuple in the common case.
+            # First-node guard before slicing (see #29): skips the nodes[i:i + m]
+            # allocation at the many positions that can't start the merge.
             if nodes[i] == first and nodes[i:i + m] == merge:
                 out.append(token)
                 i += m
@@ -152,8 +158,7 @@ class NodesSequence(GraphVertex):
 
         if len(out) == 1:
             return out[0]
-
-        merged_nodes = tuple(n.merge(token, merge) for n in out)
+        merged_nodes = tuple(node.merge(token, merge) for node in out)
         if merged_nodes == nodes:
             return self
         return NodesSequence(merged_nodes)


### PR DESCRIPTION
Reworked from the earlier lazy-out version (which read messy and only gave ~5%) to reuse the `get_merges` memo as an "is this subtree affected?" check, per review.

`_merges` (when memoized — the default) already lists **every** mergeable subsequence in the subtree, including nested ones (`yield from child.get_merges()`). So if the chosen merge isn't among them, this subtree contains it nowhere and `merge()` can return `self` immediately — skipping the scan, the child recursion, *and* the rebuild in one membership check:

```python
cached = getattr(self, "_merges", None)
if cached is not None and merge not in cached:
    return self
# ... otherwise the plain #29 scan/rebuild ...
```

Falls back to the scan when the node isn't memoized (e.g. `TRADE_MEMORY_FOR_SPEED=False`, or pre-seeded merges before any `get_merges`), so behavior is unchanged there. Output identical; 137 tests pass (rebased on current main, which now has #32/#33/#34/#36).

Measured back-to-back, 3 identical rounds (50 texts / 200 merges; time = best of 3):

| | main | this PR | Δ time | Δ mem |
|---|---|---|---|---|
| BPE | 0.655s / 1.89MB | 0.428s / 2.14MB | **−35%** | +0.25MB |
| BNE n=4 | 0.966s / 4.80MB | 0.845s / 3.63MB | **−13%** | **−1.17MB** |
| Boundless | 0.765s / 1.99MB | 0.510s / 2.28MB | **−33%** | +0.29MB |

Far bigger than the original lazy-out (−4–7%): an unaffected word now skips the scan, recursion, and rebuild in a single C-level `in` check. Memory is mixed and small (BNE −1.2MB from avoided transient rebuilds; BPE/Boundless +~0.25MB).

🤖 Generated with [Claude Code](https://claude.com/claude-code)