### PR TITLE
perf: intern single-byte Nodes in utf8

### DIFF
--- a/complex_tokenization/graphs/units.py
+++ b/complex_tokenization/graphs/units.py
@@ -35,9 +35,15 @@ def characters(s: str) -> GraphVertex:
     return NodesSequence(nodes=tuple(nodes))
 
 
+# There are only 256 single-byte values; share one immutable Node per byte
+# instead of allocating a fresh one each time. Dedups the whole leaf layer
+# (memory) and lets equal bytes compare by identity (speeds merge scans).
+_BYTE_NODES = [Node(bytes([b])) for b in range(256)]
+
+
 def utf8(s: str) -> GraphVertex:
     bytes_array = s.encode("utf-8")
-    nodes = [Node(bytes([b])) for b in bytes_array]
+    nodes = [_BYTE_NODES[b] for b in bytes_array]
     if len(nodes) == 1:
         return nodes[0]
     return NodesSequence(nodes=tuple(nodes))


### PR DESCRIPTION
`utf8` allocated a fresh `Node` for every byte of every word — but there are only 256 distinct single-byte values. Share one immutable `Node` per byte from a prebuilt table (`Node`s are frozen, so sharing is safe):

```python
_BYTE_NODES = [Node(bytes([b])) for b in range(256)]

def utf8(s):
    nodes = [_BYTE_NODES[b] for b in s.encode("utf-8")]
    ...
```

Wins on **both** axes:
- **Memory** — the entire leaf layer is deduplicated (thousands of identical byte-`Node`s collapse to ≤256 shared objects).
- **Speed** — equal bytes are now the *same object*, so the `nodes[i:i + m] == merge` tuple comparisons in `merge` hit CPython's per-element identity short-circuit instead of calling `__eq__`.

**Output identical, 137 tests pass.** Measured back-to-back (50 texts / 200 merges; time = best of 3):

| | main | this PR |
|---|---|---|
| BPE | 0.832s / 4.41MB | 0.679s / 3.30MB (−18% / −25%) |
| BNE n=4 | 1.413s / 6.28MB | 1.086s / 5.23MB (−23% / −17%) |
| Boundless | 0.948s / 4.51MB | 0.792s / 3.38MB (−16% / −25%) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)