### PR TITLE
perf: read the _merges slot directly instead of getattr

### DIFF
--- a/complex_tokenization/graph.py
+++ b/complex_tokenization/graph.py
@@ -105,7 +105,7 @@ class NodesSequence(GraphVertex):
         # returns self for unchanged subtrees, so the same objects recur across
         # merges and a full re-walk becomes a cache hit. Valid while GraphSettings
         # is fixed, which holds for a node's lifetime during training.
-        cached = getattr(self, "_merges", None)
+        cached = self._merges
         if cached is None:
             cached = tuple(self._iter_merges())
             object.__setattr__(self, "_merges", cached)
@@ -137,7 +137,7 @@ class NodesSequence(GraphVertex):
 
         # _merges (when memoized) lists every mergeable subsequence in this
         # subtree, so if the merge isn't among them nothing here changes.
-        cached = getattr(self, "_merges", None)
+        cached = self._merges
         if cached is not None and merge not in cached:
             return self
 


### PR DESCRIPTION
`_merges` is a dataclass field with a default of `None`, so it's always initialized — `getattr(self, "_merges", None)` is equivalent to `self._merges`. Both call sites (`get_merges`, `merge`) are hot (`merge` runs per subgraph per training step), so dropping the `getattr` lookup helps.

```python
-        cached = getattr(self, "_merges", None)
+        cached = self._merges
```

**Output identical, tests pass.** Measured back-to-back (50 texts / 200 merges; best of 3):

| | main | this PR |
|---|---|---|
| BPE | 0.399s | 0.386s (−3%) |
| BNE n=4 | 0.786s | 0.771s (−2%) |
| Boundless | 0.480s | 0.469s (−2%) |

Memory unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)